### PR TITLE
adds marc-overlay-context to update biblios

### DIFF
--- a/Koha/Plugin/Fi/NatLibFi/Biblios/Biblios.pm
+++ b/Koha/Plugin/Fi/NatLibFi/Biblios/Biblios.pm
@@ -81,7 +81,7 @@ sub update {
             );
         }
 
-        my $no_error = C4::Biblio::ModBiblio( $record, $biblio->biblionumber, $biblio->frameworkcode );
+        my $no_error = C4::Biblio::ModBiblio( $record, $biblio->biblionumber, $biblio->frameworkcode,  { overlay_context => { source => 'koha-plugin-rest-biblios' } } );
 
         if ( $no_error ) {
             return $c->render(


### PR DESCRIPTION
Since 21.11 it is possible to protect marc fields from being overwritten in z39.50 or other import-mechanisms. This pull request adds the overlay_context param to the call of ModBiblio to respect marc overlay rules